### PR TITLE
Prevents span duplication and multiple event bindings if $.autoGrowInput() is called multiple times.

### DIFF
--- a/jquery.auto-grow-input.js
+++ b/jquery.auto-grow-input.js
@@ -10,6 +10,7 @@
     $.fn.autoGrowInput = function(options){
         var o = $.extend({ maxWidth: 500, minWidth: 20, comfortZone: 0 }, options),
             event = 'oninput' in document.createElement('input') ? 'input' : 'keydown';
+        $('span.autogrowspan').remove();
         this.each(function(){
             var input = $(this),
                 minWidth = o.minWidth || input.width(),
@@ -26,7 +27,7 @@
                     letterSpacing: input.css('letterSpacing'),
                     whiteSpace: 'nowrap',
                     ariaHidden: true
-                }),
+                }).addClass('autogrowspan'),
                 check = function(e){
                     if (val === (val = input.val()) && !e.type == 'autogrow') return;
                     if (!val) val = input.attr('placeholder') || '';
@@ -37,6 +38,7 @@
                     if (newWidth != input.width()) input.width(newWidth);
                 };
             span.insertAfter(input);
+            input.off(event+'.autogrow autogrow');
             input.on(event+'.autogrow autogrow', check);
             // init on page load
             check();


### PR DESCRIPTION
This will allow binding the autogrow event to newly created elements after the initial call has occurred by calling $.autoGrowInput() as many times as needed.

Added class to spans to allow removal of existing spans before creating
new ones.
Added .off call to prevent multiple bindings to the same element.
